### PR TITLE
fix serving binary files

### DIFF
--- a/src/main/scala/com/jakehschwartz/finatra/swagger/DocsController.scala
+++ b/src/main/scala/com/jakehschwartz/finatra/swagger/DocsController.scala
@@ -1,5 +1,6 @@
 package com.jakehschwartz.finatra.swagger
 
+import java.io.BufferedInputStream
 import java.util.Date
 import javax.inject.{Inject, Singleton}
 
@@ -51,10 +52,11 @@ class DocsController @Inject()(swagger: Swagger,
             if (inputStream != null) {
               try {
                 val filename = getFileName(webjarsResourceURI)
-                val body = Source.fromInputStream(inputStream).mkString
+                val body = new BufferedInputStream(inputStream)
 
                 response
-                  .ok(body)
+                  .ok
+                  .body(body)
                   .header("ETag", eTagName)
                   .header("Expires", Message.httpDateFormat(new Date(System.currentTimeMillis() + defaultExpireTimeMillis)))
                   .header("Last-Modified",  Message.httpDateFormat(new Date(System.currentTimeMillis())))


### PR DESCRIPTION
Finatra errors when Swagger UI tries to request favicon

```
17:27:03.909 [finagle/netty4-1] WARN com.twitter.finatra.http.response.ResponseBuilder - Request Failure: Internal/Unhandled/java.nio.charset.MalformedInputException 
17:27:04.017 [finagle/netty4-1] ERROR com.twitter.finatra.http.internal.exceptions.ThrowableExceptionMapper - Unhandled Exception
java.nio.charset.MalformedInputException: Input length = 1
	at java.nio.charset.CoderResult.throwException(CoderResult.java:281)
	at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:339)
	at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:178)
	at java.io.InputStreamReader.read(InputStreamReader.java:184)
	at java.io.BufferedReader.read1(BufferedReader.java:210)
	at java.io.BufferedReader.read(BufferedReader.java:286)
	at java.io.Reader.read(Reader.java:140)
	at scala.io.BufferedSource.mkString(BufferedSource.scala:94)
	at com.jakehschwartz.finatra.swagger.DocsController.$anonfun$new$3(DocsController.scala:54)
```