### PR TITLE
support for Finatra route prefixes

### DIFF
--- a/src/main/scala/com/twitter/finatra/http/SwaggerRouteDSL.scala
+++ b/src/main/scala/com/twitter/finatra/http/SwaggerRouteDSL.scala
@@ -87,7 +87,17 @@ trait SwaggerRouteDSL extends RouteDSL {
   private def registerOperation(path: String, method: String)(doc: Operation => Operation): Unit = {
     FinatraSwagger
       .convert(swagger)
-      .registerOperation(path, method, doc(new Operation))
+      .registerOperation(prefixRoute(path), method, doc(new Operation))
+  }
+
+
+  //exact copy from Finatra RouteDSL class (it is defined as private there)
+  private def prefixRoute(route: String): String = {
+    contextVar().prefix match {
+      case prefix if prefix.nonEmpty && prefix.startsWith("/") => s"$prefix$route"
+      case prefix if prefix.nonEmpty && !prefix.startsWith("/") => s"/$prefix$route"
+      case _ => route
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds support for Finatra prefixes

https://twitter.github.io/finatra/user-guide/http/controllers.html#route-prefixes

(we applied and released this change internally, works well for all cases: with and without prefixes)