### PR TITLE
Update path to match swagger-ui webjar version

### DIFF
--- a/src/main/scala/com/jakehschwartz/finatra/swagger/DocsController.scala
+++ b/src/main/scala/com/jakehschwartz/finatra/swagger/DocsController.scala
@@ -28,7 +28,7 @@ class DocsController @Inject()(swagger: Swagger,
   get(s"$endpoint") { _: Request =>
     response
       .temporaryRedirect
-      .location(s"$endpoint/swagger-ui/3.2.0/index.html?url=/swagger.json")
+      .location(s"$endpoint/swagger-ui/3.9.0/index.html?url=/swagger.json")
   }
 
   private val defaultExpireTimeMillis: Long = 86400000L // 1 day


### PR DESCRIPTION
Looks like the included swagger-ui version is 3.9.0.