### PR TITLE
feat: register options route param

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For older versions, see the original repository by [xiaodongw](https://github.co
 
 The major and minor version of the library matches the Finatra major and minor version:
 
-    libraryDependencies += "com.jakehschwartz" %% "finatra-swagger" % "18.5.0"
+    libraryDependencies += "com.jakehschwartz" %% "finatra-swagger" % "18.10.0"
 
 First, create a subclass of a SwaggerModule
 

--- a/build.sbt
+++ b/build.sbt
@@ -62,3 +62,8 @@ developers := List(
   Developer(id="jakehschwartz", name="Jake Schwartz", email="jakehschwartz@gmail.com", url=url("https://www.jakehschwartz.com")),
   Developer(id="xiaodongw", name="Xiaodong Wang", email="xiaodongw79@gmail.com", url=url("https://github.com/xiaodongw"))
 )
+
+lazy val root = Project("finatra-swagger", file("."))
+
+lazy val example = Project("hello-world-example", file("examples/hello-world"))
+  .dependsOn(root)

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ scalaVersion := "2.12.7"
 
 lazy val swaggerUIVersion = SettingKey[String]("swaggerUIVersion")
 
-swaggerUIVersion := "3.19.4"
+swaggerUIVersion := "3.19.5"
 
 enablePlugins(BuildInfoPlugin)
 buildInfoPackage := "com.jakehschwartz.finatra.swagger"
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
   "io.swagger" % "swagger-core" % "1.5.21",
   "io.swagger" %% "swagger-scala-module" % "1.0.4",
   "org.webjars" % "swagger-ui" % swaggerUIVersion.value,
-  "net.bytebuddy" % "byte-buddy" % "1.9.2",
+  "net.bytebuddy" % "byte-buddy" % "1.9.3",
   "org.scalatest" %% "scalatest" % "3.0.5" % Test
 )
 

--- a/examples/hello-world/src/main/scala/com/jakehschwartz/finatra/swagger/SampleController.scala
+++ b/examples/hello-world/src/main/scala/com/jakehschwartz/finatra/swagger/SampleController.scala
@@ -15,12 +15,11 @@ class SampleFilter extends SimpleFilter[Request, Response] {
   }
 }
 
-class SampleController @Inject()(s: Swagger) extends SwaggerController {
-  override implicit protected val swagger = s
+class SampleController @Inject()(implicit val swagger: Swagger) extends SwaggerController {
 
   case class HelloResponse(text: String, time: Date)
 
-  getWithDoc("/students/:id") { o =>
+  getWithDoc("/students/:id", registerOptionsRequest = true) { o =>
     o.summary("Read student information")
       .description("Read the detail information about the student.")
       .tag("Student")
@@ -46,7 +45,7 @@ class SampleController @Inject()(s: Swagger) extends SwaggerController {
     response.ok.json(Student("Alice", "Wang", Gender.Female, new LocalDate(), 4, Some(Address("California Street", "94111")))).toFuture
   }
 
-  postWithDoc("/students/test/:id") { o =>
+  postWithDoc("/students/test/:id", registerOptionsRequest = true) { o =>
     o.summary("Sample request with route2")
       .description("Read the detail information about the student.")
       .tag("Student")
@@ -57,7 +56,7 @@ class SampleController @Inject()(s: Swagger) extends SwaggerController {
     response.ok.json(Student("Alice", "Wang", Gender.Female, new LocalDate(), 4, Some(Address("California Street", "94111")))).toFuture
   }
 
-  postWithDoc("/students/firstName") {
+  postWithDoc("/students/firstName", registerOptionsRequest = true) {
     _.request[StringWithRequest]
       .tag("Student")
   } { request: StringWithRequest =>
@@ -75,7 +74,7 @@ class SampleController @Inject()(s: Swagger) extends SwaggerController {
     response.ok.json(student).toFuture
   }
 
-  postWithDoc("/students/bulk") { o =>
+  postWithDoc("/students/bulk", registerOptionsRequest = true) { o =>
     o.summary("Create a list of students")
       .tag("Student")
       .bodyParam[Array[Student]]("students", "the list of students")
@@ -105,7 +104,7 @@ class SampleController @Inject()(s: Swagger) extends SwaggerController {
     response.ok.toFuture
   }
 
-  getWithDoc("/students") { o =>
+  getWithDoc("/students", registerOptionsRequest = true) { o =>
     o.summary("Get a list of students")
       .tag("Student")
       .responseWith[Array[String]](200, "the student ids")
@@ -114,7 +113,7 @@ class SampleController @Inject()(s: Swagger) extends SwaggerController {
     response.ok.json(Array("student1", "student2")).toFuture
   }
 
-  getWithDoc("/courses") { o =>
+  getWithDoc("/courses", registerOptionsRequest = true) { o =>
     o.summary("Get a list of courses")
       .tag("Course")
       .responseWith[Array[String]](200, "the courses ids")
@@ -123,7 +122,7 @@ class SampleController @Inject()(s: Swagger) extends SwaggerController {
     response.ok.json(Array("course1", "course2")).toFuture
   }
 
-  getWithDoc("/courses/:id") { o =>
+  getWithDoc("/courses/:id", registerOptionsRequest = true) { o =>
     o.summary("Get the detail of a course")
       .tag("Course")
       .routeParam[String]("id", "the course id")
@@ -133,7 +132,7 @@ class SampleController @Inject()(s: Swagger) extends SwaggerController {
     response.ok.json(Course(new DateTime(), "calculation", Seq("math"), CourseType.LAB, 20, BigDecimal(300.54))).toFuture
   }
 
-  filter[SampleFilter].getWithDoc("/courses/:courseId/student/:studentId") { o =>
+  filter[SampleFilter].getWithDoc("/courses/:courseId/student/:studentId", registerOptionsRequest = true) { o =>
     o.summary("Is the student in this course")
       .tags(List("Course", "Student"))
       .routeParam[String]("courseId", "the course id")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.0
+sbt.version = 1.2.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,4 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")
 
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")

--- a/src/main/scala/com/twitter/finatra/http/SwaggerRouteDSL.scala
+++ b/src/main/scala/com/twitter/finatra/http/SwaggerRouteDSL.scala
@@ -14,7 +14,7 @@ object SwaggerRouteDSL {
 trait SwaggerRouteDSL extends RouteDSL {
   implicit protected val swagger: Swagger
 
-  val NoopCallback: Request => Response = _ => response.SimpleResponse(Status.Ok, "")
+  val noopCallback: Request => Response = _ => response.SimpleResponse(Status.Ok, "")
 
   def postWithDoc[RequestType: Manifest, ResponseType: Manifest](route: String,
                                                                  name: String = "",
@@ -26,7 +26,7 @@ trait SwaggerRouteDSL extends RouteDSL {
     registerOperation(route, "post")(doc)
     post(route, name, admin, routeIndex)(callback)
     if (registerOptionsRequest) {
-      options(route, name, admin, routeIndex)(NoopCallback)
+      options(route, name, admin, routeIndex)(noopCallback)
     }
   }
 
@@ -40,7 +40,7 @@ trait SwaggerRouteDSL extends RouteDSL {
     registerOperation(route, "get")(doc)
     get(route, name, admin, routeIndex)(callback)
     if (registerOptionsRequest) {
-      options(route, name, admin, routeIndex)(NoopCallback)
+      options(route, name, admin, routeIndex)(noopCallback)
     }
   }
 
@@ -54,7 +54,7 @@ trait SwaggerRouteDSL extends RouteDSL {
     registerOperation(route, "put")(doc)
     put(route, name, admin, routeIndex)(callback)
     if (registerOptionsRequest) {
-      options(route, name, admin, routeIndex)(NoopCallback)
+      options(route, name, admin, routeIndex)(noopCallback)
     }
   }
 
@@ -68,7 +68,7 @@ trait SwaggerRouteDSL extends RouteDSL {
     registerOperation(route, "patch")(doc)
     patch(route, name, admin, routeIndex)(callback)
     if (registerOptionsRequest) {
-      options(route, name, admin, routeIndex)(NoopCallback)
+      options(route, name, admin, routeIndex)(noopCallback)
     }
   }
 
@@ -82,7 +82,7 @@ trait SwaggerRouteDSL extends RouteDSL {
     registerOperation(route, "head")(doc)
     head(route, name, admin, routeIndex)(callback)
     if (registerOptionsRequest) {
-      options(route, name, admin, routeIndex)(NoopCallback)
+      options(route, name, admin, routeIndex)(noopCallback)
     }
   }
 
@@ -96,7 +96,7 @@ trait SwaggerRouteDSL extends RouteDSL {
     registerOperation(route, "delete")(doc)
     delete(route, name, admin, routeIndex)(callback)
     if (registerOptionsRequest) {
-      options(route, name, admin, routeIndex)(NoopCallback)
+      options(route, name, admin, routeIndex)(noopCallback)
     }
   }
 

--- a/src/main/scala/com/twitter/finatra/http/SwaggerRouteDSL.scala
+++ b/src/main/scala/com/twitter/finatra/http/SwaggerRouteDSL.scala
@@ -1,7 +1,7 @@
 package com.twitter.finatra.http
 
 import com.jakehschwartz.finatra.swagger.FinatraSwagger
-import com.twitter.finagle.http.RouteIndex
+import com.twitter.finagle.http.{Request, Response, RouteIndex, Status}
 import io.swagger.models.{Operation, Swagger}
 
 /**
@@ -14,64 +14,90 @@ object SwaggerRouteDSL {
 trait SwaggerRouteDSL extends RouteDSL {
   implicit protected val swagger: Swagger
 
+  val NoopCallback: Request => Response = _ => response.SimpleResponse(Status.Ok, "")
+
   def postWithDoc[RequestType: Manifest, ResponseType: Manifest](route: String,
                                                                  name: String = "",
                                                                  admin: Boolean = false,
-                                                                 routeIndex: Option[RouteIndex] = None)
+                                                                 routeIndex: Option[RouteIndex] = None,
+                                                                 registerOptionsRequest: Boolean = false)
                                                                 (doc: Operation => Operation)
                                                                 (callback: RequestType => ResponseType): Unit = {
     registerOperation(route, "post")(doc)
     post(route, name, admin, routeIndex)(callback)
+    if (registerOptionsRequest) {
+      options(route, name, admin, routeIndex)(NoopCallback)
+    }
   }
 
   def getWithDoc[RequestType: Manifest, ResponseType: Manifest](route: String,
                                                                 name: String = "",
                                                                 admin: Boolean = false,
-                                                                routeIndex: Option[RouteIndex] = None)
+                                                                routeIndex: Option[RouteIndex] = None,
+                                                                registerOptionsRequest: Boolean = false)
                                                                (doc: Operation => Operation)
                                                                (callback: RequestType => ResponseType): Unit = {
     registerOperation(route, "get")(doc)
     get(route, name, admin, routeIndex)(callback)
+    if (registerOptionsRequest) {
+      options(route, name, admin, routeIndex)(NoopCallback)
+    }
   }
 
   def putWithDoc[RequestType: Manifest, ResponseType: Manifest](route: String,
                                                                 name: String = "",
                                                                 admin: Boolean = false,
-                                                                routeIndex: Option[RouteIndex] = None)
+                                                                routeIndex: Option[RouteIndex] = None,
+                                                                registerOptionsRequest: Boolean = false)
                                                                (doc: Operation => Operation)
                                                                (callback: RequestType => ResponseType): Unit = {
     registerOperation(route, "put")(doc)
     put(route, name, admin, routeIndex)(callback)
+    if (registerOptionsRequest) {
+      options(route, name, admin, routeIndex)(NoopCallback)
+    }
   }
 
   def patchWithDoc[RequestType: Manifest, ResponseType: Manifest](route: String,
                                                                   name: String = "",
                                                                   admin: Boolean = false,
-                                                                  routeIndex: Option[RouteIndex] = None)
+                                                                  routeIndex: Option[RouteIndex] = None,
+                                                                  registerOptionsRequest: Boolean = false)
                                                                  (doc: Operation => Operation)
                                                                  (callback: RequestType => ResponseType): Unit = {
     registerOperation(route, "patch")(doc)
     patch(route, name, admin, routeIndex)(callback)
+    if (registerOptionsRequest) {
+      options(route, name, admin, routeIndex)(NoopCallback)
+    }
   }
 
   def headWithDoc[RequestType: Manifest, ResponseType: Manifest](route: String,
                                                                  name: String = "",
                                                                  admin: Boolean = false,
-                                                                 routeIndex: Option[RouteIndex] = None)
+                                                                 routeIndex: Option[RouteIndex] = None,
+                                                                 registerOptionsRequest: Boolean = false)
                                                                 (doc: Operation => Operation)
                                                                 (callback: RequestType => ResponseType): Unit = {
     registerOperation(route, "head")(doc)
     head(route, name, admin, routeIndex)(callback)
+    if (registerOptionsRequest) {
+      options(route, name, admin, routeIndex)(NoopCallback)
+    }
   }
 
   def deleteWithDoc[RequestType: Manifest, ResponseType: Manifest](route: String,
                                                                    name: String = "",
                                                                    admin: Boolean = false,
-                                                                   routeIndex: Option[RouteIndex] = None)
+                                                                   routeIndex: Option[RouteIndex] = None,
+                                                                   registerOptionsRequest: Boolean = false)
                                                                   (doc: Operation => Operation)
                                                                   (callback: RequestType => ResponseType): Unit = {
     registerOperation(route, "delete")(doc)
     delete(route, name, admin, routeIndex)(callback)
+    if (registerOptionsRequest) {
+      options(route, name, admin, routeIndex)(NoopCallback)
+    }
   }
 
   def optionsWithDoc[RequestType: Manifest, ResponseType: Manifest](route: String,


### PR DESCRIPTION
This pr add a parameter `registerOptionsRequest`.
If you set this `true`, `OPTIONS` route will be automatically added to handle [CORS preflight requests](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request).

I also bumped dependencies and updated README.md