### PR TITLE
Improved parsing finatra request models.

### DIFF
--- a/examples/hello-world/src/main/scala/com/jakehschwartz/finatra/swagger/Models.scala
+++ b/examples/hello-world/src/main/scala/com/jakehschwartz/finatra/swagger/Models.scala
@@ -15,8 +15,8 @@ case class Student(firstName: String, lastName: String, gender: Gender, birthday
 case class StudentWithRoute(
   @RouteParam id: String,
   @Inject request: Request,
-  firstName: String,
-  lastName: String,
+  @ApiModelProperty(name = "first_name")firstName: String,
+  @ApiModelProperty(name = "last_name")lastName: String,
   gender: Gender,
   birthday: LocalDate,
   grade: Int,


### PR DESCRIPTION
Currently when processing `request` model standard swagger annotations are not respected. That means that class:

```scala
case class StudentWithRoute(
  @RouteParam id: String,
  @Inject request: Request,
  @ApiModelProperty(name = "first_name", required = true) firstName: String,
  @ApiModelProperty(name = "first_name", required = true) lastName: String,
  gender: Gender,
  birthday: LocalDate,
  grade: Int,
  emails: Array[String],
  address: Option[Address]
)
```

is resolved to:
```
{
  "firstName": "string",
  "lastName": "string",
  "gender": "Male",
  "birthday": "2019-04-09",
  "grade": 0,
  "emails": [
    "string"
  ],
  "address": {
    "street": "string",
    "zip": "string"
  }
}
```

rather than:
```
{
  "first_name": "string",
  "last_name": "string",
  "gender": "Male",
  "birthday": "2019-04-09",
  "grade": 0,
  "emails": [
    "string"
  ],
  "address": {
    "street": "string",
    "zip": "string"
  }
}
```

The purpose of this change is to leverage vanilla swagger`ModelConverters` when processing finatra `Request` model rather than rely on custom ast generation. Thanks that standard swagger annotations (like `ApiModelProperty`) are respected when docs for `body` parameter are generated. Also more complex types (like a hash map of objects) are properly represented.