### PR TITLE
reverting to v1.5.23 of swagger-core

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "io.swagger" %% "swagger-scala-module" % "1.0.6",
   "org.webjars" % "swagger-ui" % swaggerUIVersion.value,
   "net.bytebuddy" % "byte-buddy" % "1.10.5",
-  "org.scalatest" %% "scalatest" % "3.1.0" % Test
+  "org.scalatest" %% "scalatest" % "3.0.8" % Test
 )
 
 val examplesTestLibs = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,10 @@ scalaVersion := "2.12.10"
 
 crossScalaVersions := Seq("2.11.12", "2.12.10")
 
+Global / onChangedBuildSource := ReloadOnSourceChanges
+
+lazy val twitterReleaseVersion = "19.12.0"
+
 lazy val swaggerUIVersion = SettingKey[String]("swaggerUIVersion")
 
 swaggerUIVersion := "3.24.3"
@@ -15,12 +19,23 @@ buildInfoPackage := "com.jakehschwartz.finatra.swagger"
 buildInfoKeys := Seq[BuildInfoKey](name, version, swaggerUIVersion)
 
 libraryDependencies ++= Seq(
-  "com.twitter" %% "finatra-http" % "19.12.0",
-  "io.swagger" % "swagger-core" % "1.6.0",
+  "com.twitter" %% "finatra-http" % twitterReleaseVersion,
+  "io.swagger" % "swagger-core" % "1.5.23",
   "io.swagger" %% "swagger-scala-module" % "1.0.6",
   "org.webjars" % "swagger-ui" % swaggerUIVersion.value,
   "net.bytebuddy" % "byte-buddy" % "1.10.5",
   "org.scalatest" %% "scalatest" % "3.1.0" % Test
+)
+
+val examplesTestLibs = Seq(
+  "com.twitter" %% "finatra-http" % twitterReleaseVersion % "test" classifier "tests",
+  "com.twitter" %% "inject-app" % twitterReleaseVersion % "test" classifier "tests",
+  "com.twitter" %% "inject-core" % twitterReleaseVersion % "test" classifier "tests",
+  "com.twitter" %% "inject-modules" % twitterReleaseVersion % "test" classifier "tests",
+  "com.twitter" %% "inject-server" % twitterReleaseVersion % "test" classifier "tests",
+  "ch.qos.logback" % "logback-classic" % "1.2.3",
+  "org.scalatest" %% "scalatest" % "3.0.8"  % Test,
+  "org.mockito" % "mockito-all" % "1.10.19"  % Test
 )
 
 scalacOptions ++= Seq(
@@ -69,3 +84,8 @@ lazy val root = Project("finatra-swagger", file("."))
 
 lazy val example = Project("hello-world-example", file("examples/hello-world"))
   .dependsOn(root)
+  .settings(libraryDependencies ++= examplesTestLibs)
+  .settings(
+    parallelExecution in Test := true,
+    testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oDF"),
+  )

--- a/examples/hello-world/src/main/scala/com/jakehschwartz/finatra/swagger/SampleApp.scala
+++ b/examples/hello-world/src/main/scala/com/jakehschwartz/finatra/swagger/SampleApp.scala
@@ -1,41 +1,16 @@
 package com.jakehschwartz.finatra.swagger
 
-import javax.inject.Singleton
-
-import com.google.inject.Provides
+import com.google.inject.Module
 import com.twitter.finatra.http.HttpServer
 import com.twitter.finatra.http.filters.CommonFilters
 import com.twitter.finatra.http.routing.HttpRouter
-import io.swagger.models.auth.BasicAuthDefinition
-import io.swagger.models.{Info, Swagger}
 
-object SampleSwaggerModule extends SwaggerModule {
+object SampleAppMain extends SampleApp
 
-  @Singleton
-  @Provides
-  def swagger: Swagger = {
-    val swagger = new Swagger()
+class SampleApp extends HttpServer {
 
-    val info = new Info()
-      .description("The Student / Course management API, this is a sample for swagger document generation")
-      .version("1.0.1")
-      .title("Student / Course Management API")
-
-    swagger
-      .info(info)
-      .addSecurityDefinition("sampleBasic", {
-        val d = new BasicAuthDefinition()
-        d.setType("basic")
-        d
-      })
-
-    swagger
-  }
-}
-
-object SampleApp extends HttpServer {
-
-  override protected def modules = Seq(SampleSwaggerModule)
+  override val name: String = "SampleApp"
+  override protected def modules: Seq[Module] = Seq(SampleSwaggerModule)
 
   override def configureHttp(router: HttpRouter) {
     router

--- a/examples/hello-world/src/main/scala/com/jakehschwartz/finatra/swagger/SampleSwaggerModule.scala
+++ b/examples/hello-world/src/main/scala/com/jakehschwartz/finatra/swagger/SampleSwaggerModule.scala
@@ -1,0 +1,31 @@
+package com.jakehschwartz.finatra.swagger
+
+import com.google.inject.Provides
+import io.swagger.models.auth.BasicAuthDefinition
+import io.swagger.models.{Info, Swagger}
+import javax.inject.Singleton
+
+object SampleSwaggerModule extends SwaggerModule {
+
+  @Singleton
+  @Provides
+  def swagger: Swagger = {
+    val swagger = new Swagger()
+
+    val info = new Info()
+      .description(
+        "The Student / Course management API, this is a sample for swagger document generation")
+      .version("1.0.1")
+      .title("Student / Course Management API")
+
+    swagger
+      .info(info)
+      .addSecurityDefinition("sampleBasic", {
+        val d = new BasicAuthDefinition()
+        d.setType("basic")
+        d
+      })
+
+    swagger
+  }
+}

--- a/examples/hello-world/src/test/scala/com/jakehschwartz/finatra/swagger/DocsControllerTest.scala
+++ b/examples/hello-world/src/test/scala/com/jakehschwartz/finatra/swagger/DocsControllerTest.scala
@@ -1,0 +1,26 @@
+package com.jakehschwartz.finatra.swagger
+
+import com.twitter.finagle.http.{Response, Status}
+import com.twitter.finatra.http.EmbeddedHttpServer
+
+class DocsControllerTest extends SampleAppBaseTest {
+
+  override lazy val server: EmbeddedHttpServer = makeServer(
+    serverName = "docsControllerServer")
+
+  private val swaggerUrl: String =
+    s"/docs/swagger-ui/${BuildInfo.swaggerUIVersion}/index.html?url=/swagger.json"
+
+  test("sampleController: docs endpoint should return 307") {
+    val expectedLocation: String =
+      s"http://${server.externalHttpHostAndPort}$swaggerUrl"
+    val response: Response =
+      server.httpGet("/docs", andExpect = Status.TemporaryRedirect)
+    response.headerMap("Location") shouldBe expectedLocation
+  }
+
+  test("sampleController: docs endpoint should return 200 from full URL") {
+    server.httpGet(swaggerUrl, andExpect = Status.Ok)
+  }
+
+}

--- a/examples/hello-world/src/test/scala/com/jakehschwartz/finatra/swagger/SampleAppBaseTest.scala
+++ b/examples/hello-world/src/test/scala/com/jakehschwartz/finatra/swagger/SampleAppBaseTest.scala
@@ -1,0 +1,23 @@
+package com.jakehschwartz.finatra.swagger
+
+import com.google.inject.Stage
+import com.twitter.finatra.http.EmbeddedHttpServer
+import com.twitter.inject.server.FeatureTest
+import org.scalatest.Matchers
+
+trait SampleAppBaseTest extends FeatureTest with Matchers {
+
+  override protected def beforeEach(): Unit = {
+    server.assertStarted()
+    server.assertHealthy()
+  }
+
+  def stage: Stage = Stage.DEVELOPMENT
+  override def server: EmbeddedHttpServer
+
+  protected def makeServer(serverName: String): EmbeddedHttpServer = new EmbeddedHttpServer(
+    twitterServer = new SampleApp { override val name: String = serverName },
+    stage = stage
+  )
+
+}

--- a/examples/hello-world/src/test/scala/com/jakehschwartz/finatra/swagger/SampleAppBaseTest.scala
+++ b/examples/hello-world/src/test/scala/com/jakehschwartz/finatra/swagger/SampleAppBaseTest.scala
@@ -15,6 +15,9 @@ trait SampleAppBaseTest extends FeatureTest with Matchers {
   def stage: Stage = Stage.DEVELOPMENT
   override def server: EmbeddedHttpServer
 
+  // see https://twitter.github.io/finatra/user-guide/testing/feature_tests.html#sharing-a-server-fixture-between-many-feature-tests
+  // for best practices in sharing a server fixture between tests
+
   protected def makeServer(serverName: String): EmbeddedHttpServer = new EmbeddedHttpServer(
     twitterServer = new SampleApp { override val name: String = serverName },
     stage = stage

--- a/examples/hello-world/src/test/scala/com/jakehschwartz/finatra/swagger/SampleAppStartupTest.scala
+++ b/examples/hello-world/src/test/scala/com/jakehschwartz/finatra/swagger/SampleAppStartupTest.scala
@@ -1,0 +1,19 @@
+package com.jakehschwartz.finatra.swagger
+
+import com.google.inject.Stage
+import com.twitter.conversions.DurationOps._
+import com.twitter.finatra.http.EmbeddedHttpServer
+
+class SampleAppStartupTest extends SampleAppBaseTest {
+
+  override def stage: Stage = Stage.PRODUCTION
+
+  override lazy val server: EmbeddedHttpServer = makeServer("startupSampleApp")
+
+  test("Startup and be healthy") {
+    server.assertStarted()
+    server.assertHealthy()
+    server.close(20.seconds)
+    server.assertCleanShutdown()
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.6
+sbt.version = 1.3.5


### PR DESCRIPTION
Problem: 
swagger-core v1.6.0 introduces transitive Jackson deps that incompatible with Finatra's Jackson deps.

Solution:
Revert back to swagger-core v1.5.23 and introduce some basic tests to catch this.

Discussion:
tests are run with `sbt hello-world-example/test`