### PR TITLE
downgrade swagger-core to 1.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ buildInfoKeys := Seq[BuildInfoKey](name, version, swaggerUIVersion)
 
 libraryDependencies ++= Seq(
   "com.twitter" %% "finatra-http" % "19.12.0",
-  "io.swagger" % "swagger-core" % "1.6.0",
+  "io.swagger" % "swagger-core" % "1.5.24",
   "io.swagger" %% "swagger-scala-module" % "1.0.6",
   "org.webjars" % "swagger-ui" % swaggerUIVersion.value,
   "net.bytebuddy" % "byte-buddy" % "1.10.5",


### PR DESCRIPTION
As swagger-core 1.6 depends on jackson 2.10 (https://github.com/swagger-api/swagger-core/releases/tag/v1.6.0), and finatra depends on 2.9, there's jackson version incompatibility. This pr fixes it by downgrading swagger-core to 1.5.