### PR TITLE
Fix version in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For older versions, see the original repository by [xiaodongw](https://github.co
 
 The major and minor version of the library matches the Finatra major and minor version:
 ````sbt
-libraryDependencies += "com.jakehschwartz" %% "finatra-swagger" % "20.4.0"
+libraryDependencies += "com.jakehschwartz" %% "finatra-swagger" % "20.4.1"
 ````
 
 First, create a subclass of a SwaggerModule


### PR DESCRIPTION
The 20.4.0 doesn't exist on https://search.maven.org/artifact/com.jakehschwartz/finatra-swagger_2.12/20.4.0/jar

And the latest one is 20.4.1: https://search.maven.org/artifact/com.jakehschwartz/finatra-swagger_2.12/20.4.0/jar