### PR TITLE
Removed Duplicate modelConverters.readAll

### DIFF
--- a/src/main/scala/com/jakehschwartz/finatra/swagger/FinatraSwagger.scala
+++ b/src/main/scala/com/jakehschwartz/finatra/swagger/FinatraSwagger.scala
@@ -225,9 +225,7 @@ class FinatraSwagger(val openAPI: OpenAPI) {
     for (entry <- models.entrySet().asScala) {
       openAPI.schema(entry.getKey, entry.getValue)
     }
-    val schema = modelConverters.readAll(typeClass)
-
-    schema.get(typeClass.getSimpleName)
+    models.get(typeClass.getSimpleName)
   }
 
   def convertPath(path: String): String = {


### PR DESCRIPTION
Have removed the duplicate assignment of modelConverters.readAll(typeClass) value to val schema & models, This call to `modelConverters.readAll(typeClass)` take few millis. Removing should spare them.

This should help to gain a few milliseconds when the Embedded server is starting!